### PR TITLE
当前时间为5月31日，当模式是年/月时，选择6月的时候，返回6月31日，导致选择完的时候格式化后，变成7月(因为6月没有31日)

### DIFF
--- a/PGDatePicker/PGDatePicker+YearAndMonth.m
+++ b/PGDatePicker/PGDatePicker+YearAndMonth.m
@@ -20,6 +20,13 @@
     
     self.selectedComponents.year = [yearString integerValue];
     self.selectedComponents.month = [monthString integerValue];
+    
+    /// 当选了年和月，把日时分秒设置为最小值，防止因为day太大，导致出现6月31日的情况(6月没有31日)
+    self.selectedComponents.day = 1;
+    self.selectedComponents.hour = 0;
+    self.selectedComponents.minute = 0;
+    self.selectedComponents.second = 0;
+    
 }
 
 - (void)yearAndMonth_setDateWithComponents:(NSDateComponents *)components animated:(BOOL)animated {

--- a/PGDatePickerFix.podspec
+++ b/PGDatePickerFix.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.frameworks   = "UIKit"
   s.requires_arc = true
   s.dependency 'PGPickerView'
-  s.module_name  = 'PGDatePickerFix'
+  s.module_name  = 'PGDatePicker'
 end
  
  

--- a/PGDatePickerFix.podspec
+++ b/PGDatePickerFix.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |s|
-  s.name         = "PGDatePicker"
-  s.version      = "2.6.9"
+  s.name         = "PGDatePickerFix"
+  s.version      = "2.7.0"
   s.summary      = "日期选择器"
-  s.homepage     = "https://github.com/xiaozhuxiong121/PGDatePicker"
+  s.homepage     = "https://github.com/jw10126121/PGDatePicker"
   s.license      = "MIT"
-  s.author       = { "piggybear" => "piggybear_net@163.com" }
+  s.author       = { "jw10126121" => "10126121@qq.com" }
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/xiaozhuxiong121/PGDatePicker.git", :tag => s.version}
+  s.source       = { :git => "https://github.com/jw10126121/PGDatePicker.git", :tag => s.version}
   s.source_files = "PGDatePicker", "PGDatePicker/*.{h,m}"
   s.resource     = 'PGDatePicker/PGDatePicker.bundle'
   s.frameworks   = "UIKit"
   s.requires_arc = true
   s.dependency 'PGPickerView'
+  s.module_name  = 'PGDatePickerFix'
 end
  
  


### PR DESCRIPTION
当前时间为5月31日，当模式是年/月时，选择6月的时候，返回6月31日(因为默认的selectedComponents为当前时间，而选择年月时，只修改默认selectedComponents的year和month，但day没修改)，导致选择完的时候格式化后，变成7月(因为6月没有31日)
