### PR TITLE
cancelButtonText 和 confirmButtonText 设置无效

### DIFF
--- a/PGDatePicker/PGDatePickManagerHeaderView.m
+++ b/PGDatePicker/PGDatePickManagerHeaderView.m
@@ -127,11 +127,15 @@
 
 - (void)setLanguage:(NSString *)language {
     _language = language;
-    NSString *cancelButtonText = [NSBundle pg_localizedStringForKey:@"cancelButtonText" language:self.language];
-    [self.cancelButton setTitle:cancelButtonText forState:UIControlStateNormal];
+    if (!_cancelButtonText || _cancelButtonText.length <= 0) {
+        NSString *cancelButtonText = [NSBundle pg_localizedStringForKey:@"cancelButtonText" language:self.language];
+        [self.cancelButton setTitle:cancelButtonText forState:UIControlStateNormal];
+    }
     
-    NSString *confirmButtonText = [NSBundle pg_localizedStringForKey:@"confirmButtonText" language:self.language];
-    [self.confirmButton setTitle:confirmButtonText forState:UIControlStateNormal];
+    if (!_confirmButtonText || _confirmButtonText.length <= 0) {
+        NSString *confirmButtonText = [NSBundle pg_localizedStringForKey:@"confirmButtonText" language:self.language];
+        [self.confirmButton setTitle:confirmButtonText forState:UIControlStateNormal];
+    }
 }
 
 #pragma Getter


### PR DESCRIPTION

分析：
设置 `取消` `确定`按钮文案的方法有两处：
1. 在 `setLanguage:` 方法中
```
- (void)setLanguage:(NSString *)language {
    _language = language;
    
    NSString *cancelButtonText = [NSBundle pg_localizedStringForKey:@"cancelButtonText" language:self.language];
    [self.cancelButton setTitle:cancelButtonText forState:UIControlStateNormal];
    
    NSString *confirmButtonText = [NSBundle pg_localizedStringForKey:@"confirmButtonText" language:self.language];
    [self.confirmButton setTitle:confirmButtonText forState:UIControlStateNormal];
}
```

2. 在 `setupButton` 方法中
```
- (void)setupButton {
    [self.cancelButton setTitle:self.cancelButtonText forState:UIControlStateNormal];
    [self.confirmButton setTitle:self.confirmButtonText forState:UIControlStateNormal];
}
```

`setupButton`的调用时机为： `PGDatePickManagerHeaderView` 的 `layoutSubviews`时；
`setLanguage:`的调用时机为：`PGDatePickManager` 的 `viewDidLayoutSubviews`时；

在` iOS 9.3.2`系统下的表现行为是：先调用`PGDatePickManagerHeaderView` 的 `layoutSubviews`，然后调用 `PGDatePickManager` 的 `viewDidLayoutSubviews`

表现的结果是：`cancelButtonText` 和 `confirmButtonText` 无效

修复：
在 `setLanguage:` 中检查cancelButtonText，confirmButtonText 是否有值
```
- (void)setLanguage:(NSString *)language {
    _language = language;
    if (!_cancelButtonText || _cancelButtonText.length <= 0) {
        NSString *cancelButtonText = [NSBundle pg_localizedStringForKey:@"cancelButtonText" language:self.language];
        [self.cancelButton setTitle:cancelButtonText forState:UIControlStateNormal];
    }
    
    if (!_confirmButtonText || _confirmButtonText.length <= 0) {
        NSString *confirmButtonText = [NSBundle pg_localizedStringForKey:@"confirmButtonText" language:self.language];
        [self.confirmButton setTitle:confirmButtonText forState:UIControlStateNormal];
    }
}
```

